### PR TITLE
Kubernetes cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,5 @@ RUN npm install --production
 # Bundle app source
 COPY . /usr/src/app
 
-EXPOSE 8080
+EXPOSE 8081
 CMD [ "npm", "start" ]

--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   ports:
   - port: 80
-    targetPort: 9000
+    targetPort: 8081
     protocol: TCP
     name: http
   selector:
@@ -30,7 +30,7 @@ spec:
       - name: zipkin-js-example
         image: aledbf/zipkin-js-example:0.1
         ports:
-        - containerPort: 9000
+        - containerPort: 8081
         env:
           - name: ZIPKIN_URL
             value: zipkin.default.svc.cluster.local

--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -46,6 +46,8 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: zipkin-js-example
+  annotations:
+    ingress.kubernetes.io/cors-allow-headers: x-b3-sampled,x-b3-spanid,x-b3-traceid,DNT,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization
 spec:
   rules:
   - host: zipkin-js-example

--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -32,8 +32,13 @@ spec:
         ports:
         - containerPort: 8081
         env:
+        - name: ZIPKIN_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
         - name: ZIPKIN_URL
-          value: http://zipkin.default.svc.cluster.local:9411
+          value: http://zipkin.$(ZIPKIN_NAMESPACE).svc.cluster.local:9411
 
 ---
 

--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -32,8 +32,8 @@ spec:
         ports:
         - containerPort: 8081
         env:
-          - name: ZIPKIN_URL
-            value: zipkin.default.svc.cluster.local
+        - name: ZIPKIN_URL
+          value: http://zipkin.default.svc.cluster.local:9411
 
 ---
 

--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -15,8 +15,8 @@ spec:
 
 ---
 
-apiVersion: v1
-kind: ReplicationController
+apiVersion: apps/v1beta1
+kind: Deployment
 metadata:
   name: zipkin-js-example
 spec:

--- a/kubernetes/zipkin.yaml
+++ b/kubernetes/zipkin.yaml
@@ -28,3 +28,19 @@ spec:
     port: 9411
   selector:
     app: zipkin
+
+---
+
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: zipkin
+spec:
+  rules:
+  - host: zipkin
+    http:
+      paths:
+      - backend:
+          serviceName: zipkin
+          servicePort: 9411
+        path: /

--- a/kubernetes/zipkin.yaml
+++ b/kubernetes/zipkin.yaml
@@ -15,12 +15,6 @@ spec:
         image: docker.io/openzipkin/zipkin:latest
         ports:
         - containerPort: 9411
-        env:
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.namespace
 
 ---
 


### PR DESCRIPTION
Thanks for this example app. It is a huge help to have some starting points to begin from when working out how to piece together as complex a system as Zipkin on top of Kubernetes.

I had to make a few fixes in order to get this example app running on Kubernetes. With these changes, plus a couple of other tweaks[1], I was able to get this example running through the nginx ingress controller with traces starting in the browser stitched together with spans from the two example backend services.

[1] the tweaks that are not described here: updating the [`zipkinFetch` call](https://github.com/aledbf/zipkin-js-example/blob/kubernetes/browser.js#L21) to target the ingress address of the example app rather than `localhost:8081`, and using `kubectl port-forward` to forward `localhost:9411` to Zipkin deployed on the cluster. Finally, I didn't want to deal with serving up the static content from a container running on Kubernetes, so I served up the browser portion locally: after `nom run browserify`, I used `python -m SimpleHTTPServer 8080` to serve the static assets, and browsed to `http://localhost:8080/index.html`.